### PR TITLE
Handle currency magnitude keywords in TATQA extraction

### DIFF
--- a/tests/unit/test_tatqa_currency_extraction.py
+++ b/tests/unit/test_tatqa_currency_extraction.py
@@ -1,0 +1,79 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+# Stub external dependencies to allow importing TATQATask without full package installation
+sys.modules.setdefault("pandas", types.SimpleNamespace(DataFrame=object))
+
+bench_forge = types.ModuleType("bench_forge")
+sys.modules["bench_forge"] = bench_forge
+
+flame_mod = types.ModuleType("bench_forge.flame")
+adapter_mod = types.ModuleType("bench_forge.flame.adapter")
+
+
+class _DummyConfig:
+    pass
+
+
+def flame_task(name):
+    def decorator(cls):
+        return cls
+
+    return decorator
+
+
+adapter_mod.FLAMEConfig = _DummyConfig
+adapter_mod.FLAMETask = object
+adapter_mod.flame_task = flame_task
+
+sys.modules["bench_forge.flame"] = flame_mod
+sys.modules["bench_forge.flame.adapter"] = adapter_mod
+bench_forge.flame = flame_mod
+
+tasks_mod = types.ModuleType("bench_forge.tasks")
+config_mod = types.ModuleType("bench_forge.tasks.config")
+
+
+class PromptFormat:
+    ZERO_SHOT = 0
+    FEW_SHOT = 1
+
+
+config_mod.PromptFormat = PromptFormat
+tasks_mod.config = config_mod
+
+sys.modules["bench_forge.tasks"] = tasks_mod
+sys.modules["bench_forge.tasks.config"] = config_mod
+bench_forge.tasks = tasks_mod
+
+# Load module directly from file path
+tatqa_path = pathlib.Path(__file__).resolve().parents[2] / "vendor/benchforge/bench_forge/flame/tasks/tatqa.py"
+spec = importlib.util.spec_from_file_location("tatqa", tatqa_path)
+tatqa = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(tatqa)  # type: ignore[assignment]
+TATQATask = tatqa.TATQATask
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("The revenue was $5 million.", "5000000"),
+        ("The investment reached 3 billion dollars", "3000000000"),
+        ("Net worth stands at $2.5 trillion", "2500000000000"),
+        ("Funding totaled $4M last year", "4000000"),
+        ("The deal was valued at 7B dollars", "7000000000"),
+        ("Budget was $6T", "6000000000000"),
+    ],
+)
+def test_extract_currency_with_magnitude(text: str, expected: str) -> None:
+    task = object.__new__(TATQATask)
+    assert task._extract_currency(text) == expected

--- a/vendor/benchforge/bench_forge/flame/tasks/tatqa.py
+++ b/vendor/benchforge/bench_forge/flame/tasks/tatqa.py
@@ -266,15 +266,43 @@ Step 3 - Final answer:"""
     def _extract_currency(self, response: str) -> Optional[str]:
         """Extract currency amounts."""
         currency_patterns = [
-            r"\$?([\d,]+\.?\d*)\s*(?:million|billion|trillion|M|B|T)?",
+            r"\$?([\d,]+\.?\d*)\s*(million|billion|trillion|thousand|M|B|T|K)?",
             r"([\d,]+\.?\d*)\s*dollars?",
         ]
 
+        magnitude_multipliers = {
+            "k": 1_000,
+            "thousand": 1_000,
+            "m": 1_000_000,
+            "million": 1_000_000,
+            "b": 1_000_000_000,
+            "billion": 1_000_000_000,
+            "t": 1_000_000_000_000,
+            "trillion": 1_000_000_000_000,
+        }
+
         for pattern in currency_patterns:
             matches = re.findall(pattern, response, re.IGNORECASE)
-            if matches:
-                amount = matches[-1].strip()
-                return self._clean_numerical_answer(amount)
+            if not matches:
+                continue
+
+            match = matches[-1]
+            if isinstance(match, tuple):
+                amount, magnitude = match[0], match[1]
+            else:
+                amount, magnitude = match, ""
+
+            cleaned_amount = self._clean_numerical_answer(amount)
+            if cleaned_amount is None:
+                continue
+
+            value = float(cleaned_amount)
+            if magnitude:
+                multiplier = magnitude_multipliers.get(magnitude.lower(), 1)
+                value *= multiplier
+
+            amount_str = str(int(value)) if value.is_integer() else str(value)
+            return self._clean_numerical_answer(amount_str)
 
         return None
 


### PR DESCRIPTION
## Summary
- detect magnitude words (million, billion, etc.) in currency extraction
- scale numeric values accordingly
- add tests covering currency magnitudes like "$5 million"

## Testing
- `pytest -c /dev/null --confcutdir=tests/unit tests/unit/test_tatqa_currency_extraction.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a925e536cc83238c46d783f1c3de70